### PR TITLE
Add memcached autodiscovery

### DIFF
--- a/pkg/cacheutil/memcached_client.go
+++ b/pkg/cacheutil/memcached_client.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
+	memcacheDiscovery "github.com/thanos-io/thanos/pkg/discovery/memcache"
 	"github.com/thanos-io/thanos/pkg/extprom"
 	"github.com/thanos-io/thanos/pkg/gate"
 	"github.com/thanos-io/thanos/pkg/model"
@@ -53,6 +54,7 @@ var (
 		MaxGetMultiConcurrency:    100,
 		MaxGetMultiBatchSize:      0,
 		DNSProviderUpdateInterval: 10 * time.Second,
+		AutoDiscovery:             false,
 	}
 )
 
@@ -114,6 +116,9 @@ type MemcachedClientConfig struct {
 
 	// DNSProviderUpdateInterval specifies the DNS discovery update interval.
 	DNSProviderUpdateInterval time.Duration `yaml:"dns_provider_update_interval"`
+
+	// AutoDiscovery configures memached client to perform auto-discovery instead of DNS resolution
+	AutoDiscovery bool `yaml:"auto_discovery"`
 }
 
 func (c *MemcachedClientConfig) validate() error {
@@ -153,8 +158,8 @@ type memcachedClient struct {
 	// Name provides an identifier for the instantiated Client
 	name string
 
-	// DNS provider used to keep the memcached servers list updated.
-	dnsProvider *dns.Provider
+	// Address provider used to keep the memcached servers list updated.
+	addressProvider AddressProvider
 
 	// Channel used to notify internal goroutines when they should quit.
 	stop chan struct{}
@@ -175,6 +180,11 @@ type memcachedClient struct {
 	skipped    *prometheus.CounterVec
 	duration   *prometheus.HistogramVec
 	dataSize   *prometheus.HistogramVec
+}
+
+type AddressProvider interface {
+	Resolve(context.Context, []string) error
+	Addresses() []string
 }
 
 type memcachedGetMultiResult struct {
@@ -220,20 +230,30 @@ func newMemcachedClient(
 	reg prometheus.Registerer,
 	name string,
 ) (*memcachedClient, error) {
-	dnsProvider := dns.NewProvider(
-		logger,
-		extprom.WrapRegistererWithPrefix("thanos_memcached_", reg),
-		dns.GolangResolverType,
-	)
+	promRegisterer := extprom.WrapRegistererWithPrefix("thanos_memcached_", reg)
+
+	var addressProvider AddressProvider
+	if config.AutoDiscovery {
+		addressProvider = memcacheDiscovery.NewProvider(
+			logger,
+			promRegisterer,
+			2*time.Second)
+	} else {
+		addressProvider = dns.NewProvider(
+			logger,
+			extprom.WrapRegistererWithPrefix("thanos_memcached_", reg),
+			dns.GolangResolverType,
+		)
+	}
 
 	c := &memcachedClient{
-		logger:      log.With(logger, "name", name),
-		config:      config,
-		client:      client,
-		selector:    selector,
-		dnsProvider: dnsProvider,
-		asyncQueue:  make(chan func(), config.MaxAsyncBufferSize),
-		stop:        make(chan struct{}, 1),
+		logger:          log.With(logger, "name", name),
+		config:          config,
+		client:          client,
+		selector:        selector,
+		addressProvider: addressProvider,
+		asyncQueue:      make(chan func(), config.MaxAsyncBufferSize),
+		stop:            make(chan struct{}, 1),
 		getMultiGate: gate.New(
 			extprom.WrapRegistererWithPrefix("thanos_memcached_getmulti_", reg),
 			config.MaxGetMultiConcurrency,
@@ -561,11 +581,11 @@ func (c *memcachedClient) resolveAddrs() error {
 	defer cancel()
 
 	// If some of the dns resolution fails, log the error.
-	if err := c.dnsProvider.Resolve(ctx, c.config.Addresses); err != nil {
+	if err := c.addressProvider.Resolve(ctx, c.config.Addresses); err != nil {
 		level.Error(c.logger).Log("msg", "failed to resolve addresses for memcached", "addresses", strings.Join(c.config.Addresses, ","), "err", err)
 	}
 	// Fail in case no server address is resolved.
-	servers := c.dnsProvider.Addresses()
+	servers := c.addressProvider.Addresses()
 	if len(servers) == 0 {
 		return fmt.Errorf("no server address resolved for %s", c.name)
 	}

--- a/pkg/discovery/memcache/provider.go
+++ b/pkg/discovery/memcache/provider.go
@@ -1,0 +1,102 @@
+package memcache
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/thanos/pkg/errutil"
+	"github.com/thanos-io/thanos/pkg/extprom"
+	"sync"
+	"time"
+)
+
+type Provider struct {
+	sync.RWMutex
+	resolver       Resolver
+	clusterConfigs map[string]*ClusterConfig
+	logger         log.Logger
+
+	configVersion         *extprom.TxGaugeVec
+	resolvedAddresses     *extprom.TxGaugeVec
+	resolverFailuresCount prometheus.Counter
+	resolverLookupsCount  prometheus.Counter
+}
+
+func NewProvider(logger log.Logger, reg prometheus.Registerer, dialTimeout time.Duration) *Provider {
+	p := &Provider{
+		resolver:       &memcachedAutoDiscovery{dialTimeout: dialTimeout},
+		clusterConfigs: map[string]*ClusterConfig{},
+		configVersion: extprom.NewTxGaugeVec(reg, prometheus.GaugeOpts{
+			Name: "auto_discovery_config_version",
+			Help: "The current auto discovery config version",
+		}, []string{"addr"}),
+		resolvedAddresses: extprom.NewTxGaugeVec(reg, prometheus.GaugeOpts{
+			Name: "auto_discovery_resolved_addresses",
+			Help: "The number of memcached nodes found via auto discovery",
+		}, []string{"addr"}),
+		resolverLookupsCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "auto_discovery_total",
+			Help: "The number of memcache auto discovery attempts",
+		}),
+		resolverFailuresCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "auto_discovery_failures_total",
+			Help: "The number of memcache auto discovery failures",
+		}),
+	}
+	return p
+}
+
+func (p *Provider) Resolve(ctx context.Context, addresses []string) error {
+	clusterConfigs := map[string]*ClusterConfig{}
+	errs := errutil.MultiError{}
+
+	for _, address := range addresses {
+		clusterConfig, err := p.resolver.Resolve(ctx, address)
+		p.resolverLookupsCount.Inc()
+
+		if err != nil {
+			level.Warn(p.logger).Log(
+				"msg", "failed to perform auto-discovery for memcached",
+				"address", address,
+			)
+			errs.Add(err)
+			p.resolverFailuresCount.Inc()
+
+			// Use cached values.
+			p.RLock()
+			clusterConfigs[address] = p.clusterConfigs[address]
+			p.RUnlock()
+		} else {
+			clusterConfigs[address] = clusterConfig
+		}
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	p.resolvedAddresses.ResetTx()
+	p.configVersion.ResetTx()
+	for address, config := range clusterConfigs {
+		p.resolvedAddresses.WithLabelValues(address).Set(float64(len(config.nodes)))
+		p.configVersion.WithLabelValues(address).Set(float64(config.version))
+	}
+	p.resolvedAddresses.Submit()
+	p.configVersion.Submit()
+
+	p.clusterConfigs = clusterConfigs
+
+	return errs.Err()
+}
+
+func (p *Provider) Addresses() []string {
+	var result []string
+	for _, config := range p.clusterConfigs {
+		for _, node := range config.nodes {
+			result = append(result, fmt.Sprintf("%s:%d", node.dns, node.port))
+		}
+	}
+	return result
+}

--- a/pkg/discovery/memcache/provider_test.go
+++ b/pkg/discovery/memcache/provider_test.go
@@ -1,0 +1,83 @@
+package memcache
+
+import (
+	"context"
+	"errors"
+	"github.com/go-kit/kit/log"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestProviderUpdatesAddresses(t *testing.T) {
+	ctx := context.TODO()
+	clusters := []string{"memcached-cluster-1", "memcached-cluster-2"}
+	provider := NewProvider(log.NewNopLogger(), nil, 5*time.Second)
+	resolver := mockResolver{
+		configs: map[string]*ClusterConfig{
+			"memcached-cluster-1": {nodes: []Node{{dns: "dns-1", ip: "ip-1", port: 11211}}},
+			"memcached-cluster-2": {nodes: []Node{{dns: "dns-2", ip: "ip-2", port: 8080}}},
+		},
+	}
+	provider.resolver = &resolver
+
+	err := provider.Resolve(ctx, clusters)
+	addresses := provider.Addresses()
+	sort.Strings(addresses)
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"dns-1:11211", "dns-2:8080"}, addresses)
+
+	resolver.configs = map[string]*ClusterConfig{
+		"memcached-cluster-1": {nodes: []Node{{dns: "dns-1", ip: "ip-1", port: 11211}, {dns: "dns-3", ip: "ip-3", port: 11211}}},
+		"memcached-cluster-2": {nodes: []Node{{dns: "dns-2", ip: "ip-2", port: 8080}}},
+	}
+	err = provider.Resolve(ctx, clusters)
+	addresses = provider.Addresses()
+	sort.Strings(addresses)
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"dns-1:11211", "dns-2:8080", "dns-3:11211"}, addresses)
+}
+
+func TestProviderDoesNotUpdateAddressIfFailed(t *testing.T) {
+	ctx := context.TODO()
+	clusters := []string{"memcached-cluster-1", "memcached-cluster-2"}
+	provider := NewProvider(log.NewNopLogger(), nil, 5*time.Second)
+	resolver := mockResolver{
+		configs: map[string]*ClusterConfig{
+			"memcached-cluster-1": {nodes: []Node{{dns: "dns-1", ip: "ip-1", port: 11211}}},
+			"memcached-cluster-2": {nodes: []Node{{dns: "dns-2", ip: "ip-2", port: 8080}}},
+		},
+	}
+	provider.resolver = &resolver
+
+	err := provider.Resolve(ctx, clusters)
+	addresses := provider.Addresses()
+	sort.Strings(addresses)
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, []string{"dns-1:11211", "dns-2:8080"}, addresses)
+
+	resolver.configs = nil
+	resolver.err = errors.New("oops")
+	err = provider.Resolve(ctx, clusters)
+	addresses = provider.Addresses()
+	sort.Strings(addresses)
+
+	testutil.NotOk(t, err)
+	testutil.Equals(t, []string{"dns-1:11211", "dns-2:8080"}, addresses)
+}
+
+type mockResolver struct {
+	configs map[string]*ClusterConfig
+	err     error
+}
+
+func (r *mockResolver) Resolve(_ context.Context, address string) (*ClusterConfig, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.configs[address], nil
+}

--- a/pkg/discovery/memcache/resolver.go
+++ b/pkg/discovery/memcache/resolver.go
@@ -1,0 +1,109 @@
+package memcache
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ClusterConfig struct {
+	version int
+	nodes   []Node
+}
+
+type Node struct {
+	dns  string
+	ip   string
+	port int
+}
+
+type Resolver interface {
+	// Resolve performs a DNS lookup and returns a list of records.
+	// name is the domain name to be resolved.
+	// qtype is the query type. Accepted values are `dns` for A/AAAA lookup and `dnssrv` for SRV lookup.
+	// If scheme is passed through name, it is preserved on IP results.
+	Resolve(ctx context.Context, address string) (*ClusterConfig, error)
+}
+
+type memcachedAutoDiscovery struct {
+	dialTimeout time.Duration
+}
+
+func (s *memcachedAutoDiscovery) Resolve(ctx context.Context, address string) (config *ClusterConfig, err error) {
+	conn, err := net.DialTimeout("tcp", address, s.dialTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = conn.Close()
+	}()
+
+	rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
+	if _, err := fmt.Fprintf(rw, "config get cluster\n"); err != nil {
+		return nil, err
+	}
+	if err := rw.Flush(); err != nil {
+		return nil, err
+	}
+
+	config, err = s.parseConfig(rw.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, err
+}
+
+func (s *memcachedAutoDiscovery) parseConfig(reader *bufio.Reader) (*ClusterConfig, error) {
+	clusterConfig := new(ClusterConfig)
+
+	configMeta, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config metadata: %s", err)
+	}
+	configMeta = strings.TrimSpace(configMeta)
+
+	// First line should be "CONFIG cluster 0 [length-of-payload-]
+	configMetaComponents := strings.Split(configMeta, " ")
+	if len(configMetaComponents) != 4 {
+		return nil, fmt.Errorf("expected 4 components in config metadata, and recieved %d, meta: %s", len(configMetaComponents), configMeta)
+	}
+
+	configSize, err := strconv.Atoi(configMetaComponents[3])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config size from metadata: %s, error: %s", configMeta, err)
+	}
+
+	configVersion, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("failed to find config version: %s", err)
+	}
+	clusterConfig.version, err = strconv.Atoi(strings.TrimSpace(configVersion))
+
+	nodes, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("failed to read nodes: %s", err)
+	}
+
+	if len(configVersion)+len(nodes) != configSize {
+		return nil, fmt.Errorf("expected %d in config payload, but got %d instead.", configSize, len(configVersion)+len(nodes))
+	}
+
+	for _, host := range strings.Split(strings.TrimSpace(nodes), " ") {
+		dnsIpPort := strings.Split(host, "|")
+		if len(dnsIpPort) != 3 {
+			return nil, fmt.Errorf("node not in expected format: %s", dnsIpPort)
+		}
+		port, err := strconv.Atoi(dnsIpPort[2])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse port: %s, err: %s", dnsIpPort, err)
+		}
+		clusterConfig.nodes = append(clusterConfig.nodes, Node{dns: dnsIpPort[0], ip: dnsIpPort[1], port: port})
+	}
+
+	return clusterConfig, nil
+}

--- a/pkg/discovery/memcache/resolver_test.go
+++ b/pkg/discovery/memcache/resolver_test.go
@@ -1,0 +1,75 @@
+package memcache
+
+import (
+	"bufio"
+	"errors"
+	"github.com/thanos-io/thanos/pkg/testutil"
+	"strings"
+	"testing"
+)
+
+func TestGoodClusterConfigs(t *testing.T) {
+	resolver := memcachedAutoDiscovery{}
+	testCases := []struct {
+		content string
+		config  ClusterConfig
+	}{
+		{"CONFIG cluster 0 23\r\n100\r\ndns-1|ip-1|11211\r\nEND\r\n",
+			ClusterConfig{nodes: []Node{{dns: "dns-1", ip: "ip-1", port: 11211}}, version: 100},
+		},
+		{"CONFIG cluster 0 37\r\n0\r\ndns-1|ip-1|11211 dns-2|ip-2|8080\r\nEND\r\n",
+			ClusterConfig{nodes: []Node{{dns: "dns-1", ip: "ip-1", port: 11211}, {dns: "dns-2", ip: "ip-2", port: 8080}}, version: 0},
+		},
+	}
+
+	for _, testCase := range testCases {
+		reader := bufio.NewReader(strings.NewReader(testCase.content))
+
+		config, err := resolver.parseConfig(reader)
+
+		testutil.Ok(t, err)
+		testutil.Equals(t, testCase.config, *config)
+	}
+}
+
+func TestBadClusterConfigs(t *testing.T) {
+	resolver := memcachedAutoDiscovery{}
+	testCases := []struct {
+		content     string
+		expectedErr error
+	}{
+		{"",
+			errors.New("failed to read config metadata: EOF"),
+		},
+		{"CONFIG cluster\r\n",
+			errors.New("expected 4 components in config metadata, and recieved 2, meta: CONFIG cluster"),
+		},
+		{"CONFIG cluster 0 configSize\r\n",
+			errors.New("failed to parse config size from metadata: CONFIG cluster 0 configSize, error: strconv.Atoi: parsing \"configSize\": invalid syntax"),
+		},
+		{"CONFIG cluster 0 100\r\n",
+			errors.New("failed to find config version: EOF"),
+		},
+		{"CONFIG cluster 0 100\r\n0\r\n",
+			errors.New("failed to read nodes: EOF"),
+		},
+		{"CONFIG cluster 0 0\r\n100\r\ndns-1|ip-1|11211\r\nEND\r\n",
+			errors.New("expected 0 in config payload, but got 23 instead."),
+		},
+		{"CONFIG cluster 0 17\r\n100\r\ndns-1|ip-1\r\nEND\r\n",
+			errors.New("node not in expected format: [dns-1 ip-1]"),
+		},
+		{"CONFIG cluster 0 22\r\n100\r\ndns-1|ip-1|port\r\nEND\r\n",
+			errors.New("failed to parse port: [dns-1 ip-1 port], err: strconv.Atoi: parsing \"port\": invalid syntax"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		reader := bufio.NewReader(strings.NewReader(testCase.content))
+
+		_, err := resolver.parseConfig(reader)
+
+		testutil.Assert(t, testCase.expectedErr.Error() == err.Error(), "expected error '%v', but got '%v'", testCase.expectedErr.Error(), err.Error())
+	}
+
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
* Add a flag to enable auto-discovery for memcached
* Add a new provider/resolver for auto-discovery

## Verification
* Integrated into cortex, and verified that auto-discovery is able to find scaled up nodes without having to restart pods
* Tested with [AWS ElastiCache Auto Discovery](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.HowAutoDiscoveryWorks.html), but should work with [Google Cloud ](https://cloud.google.com/memorystore/docs/memcached/auto-discovery-overview)too, since the protocol seem the same

